### PR TITLE
予約編集機能の編集

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -26,7 +26,10 @@ class ReservationsController < ApplicationController
     @reservation = Reservation.find(params[:id])
   end
 
-  def updated
+  def update
+    @reservation = Reservation.find(params[:id])
+    @reservation.update(reservation_parameter)
+    redirect_to root_path
   end
 
   def destroy

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -28,8 +28,11 @@ class ReservationsController < ApplicationController
 
   def update
     @reservation = Reservation.find(params[:id])
-    @reservation.update(reservation_parameter)
-    redirect_to root_path
+    if @reservation.update(reservation_parameter)
+      redirect_to root_path
+    else
+      render :edit
+    end
   end
 
   def destroy


### PR DESCRIPTION
＃What
予約編集機能の再実装
＃Why
・updateアクションが正しく定義されていなかった為
・DBへの保存の成功、失敗で遷移先を変える為